### PR TITLE
Rebuild pairing and stage flows

### DIFF
--- a/Tele Teams/CameraPublisherView.swift
+++ b/Tele Teams/CameraPublisherView.swift
@@ -217,9 +217,12 @@ extension CameraPublisherViewModel: AVCaptureVideoDataOutputSampleBufferDelegate
 struct CameraPublisherView: View {
     @StateObject private var vm: CameraPublisherViewModel
     @State private var previewLayer = AVCaptureVideoPreviewLayer()
+    @State private var hasAutoStarted = false
+    private let autoStartPublishing: Bool
 
-    init(sender: MediaSender) {
+    init(sender: MediaSender, autoStartPublishing: Bool = false) {
         _vm = StateObject(wrappedValue: CameraPublisherViewModel(sender: sender))
+        self.autoStartPublishing = autoStartPublishing
     }
 
     var body: some View {
@@ -257,7 +260,13 @@ struct CameraPublisherView: View {
             }
         }
         .onAppear {
-            Task { await vm.configureAndStartPreview(on: previewLayer) }
+            Task {
+                await vm.configureAndStartPreview(on: previewLayer)
+                if autoStartPublishing && !hasAutoStarted {
+                    hasAutoStarted = true
+                    vm.startPublishing()
+                }
+            }
         }
         .onDisappear { vm.stopPublishing() }
         .preferredColorScheme(.dark)

--- a/Tele Teams/ContentView.swift
+++ b/Tele Teams/ContentView.swift
@@ -2,573 +2,523 @@
 //  ContentView.swift
 //  Tele Teams
 //
-//  Created by Chris on 2025-09-20.
+//  Reimagined pairing-first experience.
 //
 
 import SwiftUI
+import Combine
 
-// MARK: - Models
-struct StageParticipant: Identifiable, Hashable {
-    let device: Device
-    let feed: DeviceVideoFeed
-
-    var id: UUID { device.id }
-    var name: String { device.name }
-    var isSpeaking: Bool { feed.isSpeaking }
-    var isMuted: Bool { feed.isMuted }
-    var isVideoOff: Bool { !feed.isVideoEnabled }
-
-    static func == (lhs: StageParticipant, rhs: StageParticipant) -> Bool {
-        lhs.device.id == rhs.device.id
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(device.id)
-    }
-}
-
-// MARK: - Root View
 struct ContentView: View {
-    @StateObject private var deviceManager = DeviceManager()
-    @State private var showConnectivityManager = false
-    @State private var showCameraPublisher = false
-    @State private var selectedDeviceId: UUID?
-    @State private var activeSender: MediaSender?
-    @State private var cameraError: String?
-    @Environment(\.horizontalSizeClass) private var hSizeClass
-    private enum CompactTab: String, CaseIterable { case stage = "Stage", participants = "Participants" }
-    @State private var compactTab: CompactTab = .stage
-
-    private var stageParticipants: [StageParticipant] {
-        deviceManager.paired
-            .filter { $0.connection == .connected && $0.roles.contains(.camera) }
-            .map { StageParticipant(device: $0, feed: deviceManager.feed(for: $0)) }
-            .sorted { $0.name < $1.name }
-    }
+    @StateObject private var coordinator = AppCoordinator()
 
     var body: some View {
         Group {
-            if hSizeClass == .compact {
-                // iPhone-friendly compact layout
-                ZStack {
-                    LinearGradient(
-                        colors: [
-                            Color(hue: 0.66, saturation: 0.65, brightness: 0.24),
-                            Color(hue: 0.74, saturation: 0.65, brightness: 0.25)
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                    .ignoresSafeArea()
-
-                    VStack(spacing: 12) {
-                        // Top segmented control to switch between Stage and Participants
-                        Picker("Section", selection: $compactTab) {
-                            ForEach(CompactTab.allCases, id: \.self) { tab in
-                                Text(tab.rawValue).tag(tab)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .padding(.horizontal, 16)
-                        .padding(.top, 8)
-
-                        // Content area
-                        Group {
-                            switch compactTab {
-                            case .stage:
-                                ScrollView {
-                                    StageGrid(participants: stageParticipants,
-                                              selectedId: $selectedDeviceId,
-                                              isCompact: hSizeClass == .compact,
-                                              onSelect: { selectedDeviceId = $0 })
-                                    .padding(.horizontal, 12)
-                                    .padding(.top, 8)
-                                }
-                            case .participants:
-                                ScrollView {
-                                    Sidebar(
-                                        participants: stageParticipants,
-                                        selectedId: $selectedDeviceId,
-                                        onSettings: { showConnectivityManager = true },
-                                        onCamera: presentCameraPublisher,
-                                        onBluetooth: { print("Bluetooth tapped") }
-                                    )
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.horizontal, 12)
-                                    .padding(.top, 4)
-                                }
-                            }
-                        }
-
-                        Spacer(minLength: 0)
-                    }
+            switch coordinator.route {
+            case .pairing:
+                PairingScreen(model: coordinator.pairingModel)
+                    .transition(.opacity)
+            case .roleSelection(let peer):
+                RoleSelectionScreen(peer: peer) { role in
+                    coordinator.confirmRole(role, for: peer)
+                } onBack: {
+                    coordinator.cancelRoleSelection()
                 }
-                // Keep bottom controls visible above the home indicator
-                .safeAreaInset(edge: .bottom) {
-                    BottomControlBar(
-                        onToggleMute: { toggleMuteSelected() },
-                        onToggleVideo: { toggleVideoSelected() },
-                        onShareScreen: { print("Share Screen tapped") },
-                        onMore: { print("More tapped") },
-                        onMention: { print("Mention tapped") }
-                    )
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 6)
+                .transition(.move(edge: .trailing))
+            case .stage(let session):
+                StageScreen(session: session) { endedSession in
+                    coordinator.endSession(endedSession)
                 }
-            } else {
-                // Regular iPad/large layout
-                HStack(spacing: 0) {
-                    Sidebar(
-                        participants: stageParticipants,
-                        selectedId: $selectedDeviceId,
-                        onSettings: { showConnectivityManager = true },
-                        onCamera: presentCameraPublisher,
-                        onBluetooth: { print("Bluetooth tapped") }
-                    )
-                        .frame(width: 320)
-                        .background(
-                            LinearGradient(
-                                colors: [Color(hue: 0.62, saturation: 0.68, brightness: 0.20),
-                                         Color(hue: 0.70, saturation: 0.69, brightness: 0.16)],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-
-                    Divider().opacity(0.12)
-
-                    ZStack {
-                        LinearGradient(
-                            colors: [
-                                Color(hue: 0.66, saturation: 0.65, brightness: 0.24),
-                                Color(hue: 0.74, saturation: 0.65, brightness: 0.25)
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                        .ignoresSafeArea()
-
-                        VStack(spacing: 16) {
-                            StageGrid(participants: stageParticipants,
-                                      selectedId: $selectedDeviceId,
-                                      isCompact: hSizeClass == .compact,
-                                      onSelect: { selectedDeviceId = $0 })
-                                .padding(.horizontal, 20)
-                                .padding(.top, 20)
-
-                            Spacer(minLength: 6)
-
-                            BottomControlBar(
-                                onToggleMute: { toggleMuteSelected() },
-                                onToggleVideo: { toggleVideoSelected() },
-                                onShareScreen: { print("Share Screen tapped") },
-                                onMore: { print("More tapped") },
-                                onMention: { print("Mention tapped") }
-                            )
-                            .padding(.bottom, 18)
-                        }
-                    }
-                }
+                .transition(.opacity.combined(with: .scale))
             }
         }
-        .sheet(isPresented: $showConnectivityManager) {
-            ConnectivityManagerView(deviceManager: deviceManager)
-                .presentationDetents([.medium, .large])
-                .presentationDragIndicator(.visible)
-                .preferredColorScheme(.dark)
-        }
-        .sheet(isPresented: $showCameraPublisher, onDismiss: { activeSender = nil }) {
-            if let sender = activeSender {
-                CameraPublisherView(sender: sender)
-                    .preferredColorScheme(.dark)
-            } else {
-                Text("Select a camera-enabled device from the Device Manager.")
-                    .padding()
-            }
-        }
+        .animation(.easeInOut, value: coordinator.routeID)
         .preferredColorScheme(.dark)
-        .onAppear {
-            alignSelection()
-        }
-        .onReceive(deviceManager.$paired) { _ in alignSelection() }
-        .alert("Camera Publisher", isPresented: .init(
-            get: { cameraError != nil },
-            set: { if !$0 { cameraError = nil } }
-        ), presenting: cameraError) { _ in
-            Button("OK", role: .cancel) {}
-        } message: { message in
-            Text(message)
-        }
-    }
-
-    private func toggleMuteSelected() {
-        guard let id = selectedDeviceId else { return }
-        deviceManager.toggleMute(for: id)
-    }
-
-    private func toggleVideoSelected() {
-        guard let id = selectedDeviceId else { return }
-        deviceManager.toggleVideo(for: id)
-    }
-
-    private func alignSelection() {
-        let participants = stageParticipants
-        if let current = selectedDeviceId, participants.contains(where: { $0.id == current }) {
-            return
-        }
-        selectedDeviceId = participants.first?.id
-    }
-
-    private func presentCameraPublisher() {
-        guard let target = cameraTargetDevice() else {
-            cameraError = "No camera-capable devices are paired. Pair and connect a device in the Connectivity Manager first."
-            return
-        }
-        if target.connection == .disconnected {
-            deviceManager.connect(target)
-        }
-        if !target.roles.contains(.camera) {
-            deviceManager.assign(.camera, to: target)
-        }
-        guard let sender = deviceManager.mediaSender(for: target.id) else {
-            cameraError = "Unable to create a media sender for \(target.name)."
-            return
-        }
-        activeSender = sender
-        showCameraPublisher = true
-    }
-
-    private func cameraTargetDevice() -> Device? {
-        if let id = selectedDeviceId, let device = deviceManager.device(for: id) {
-            return device
-        }
-        if let connectedCamera = deviceManager.paired.first(where: { $0.roles.contains(.camera) && $0.connection == .connected }) {
-            return connectedCamera
-        }
-        return deviceManager.paired.first(where: { $0.capabilities.contains(.camera) })
     }
 }
 
-// MARK: - Sidebar
-struct Sidebar: View {
-    var participants: [StageParticipant]
-    @Binding var selectedId: UUID?
-    var onSettings: () -> Void
-    var onCamera: () -> Void
-    var onBluetooth: () -> Void
+// MARK: - Pairing Flow
+
+private struct PairingScreen: View {
+    @ObservedObject var model: PairingModel
 
     var body: some View {
-        VStack(spacing: 16) {
-            // Title
-            HStack {
-                Text("Participants (")
-                    .font(.headline)
-                    .foregroundStyle(.white.opacity(0.9))
-                + Text("\(participants.count)")
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(.white)
-                + Text(")")
-                    .font(.headline)
-                    .foregroundStyle(.white.opacity(0.9))
-                Spacer()
-            }
-            .padding(.top, 20)
-            .padding(.horizontal, 16)
-
-            // List
-            VStack(spacing: 12) {
-                ForEach(participants) { p in
-                    ParticipantRow(participant: p, isSelected: p.id == selectedId)
-                        .onTapGesture { selectedId = p.id }
-                }
-            }
-            .padding(.horizontal, 12)
-
-            Spacer()
-
-            // Connection quality card
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Connection Quality")
-                    .font(.subheadline)
-                    .foregroundStyle(.white.opacity(0.9))
-
-                HStack(spacing: 8) {
-                    ForEach(0..<3) { _ in
-                        Circle()
-                            .frame(width: 8, height: 8)
-                            .foregroundStyle(.green)
-                    }
-                    Spacer()
-                    Text("Excellent")
-                        .font(.subheadline)
-                        .foregroundStyle(.green)
-                }
-            }
-            .padding(14)
-            .background(.ultraThinMaterial.opacity(0.15))
-            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .padding(.horizontal, 16)
-
-            // Footer buttons
-            HStack(spacing: 18) {
-                FooterCircleButton(systemName: "gearshape", action: onSettings)
-                FooterCircleButton(systemName: "camera", action: onCamera)
-                FooterCircleButton(systemName: "bluetooth", action: onBluetooth)
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.bottom, 16)
-        }
-    }
-}
-
-struct ParticipantRow: View {
-    let participant: StageParticipant
-    var isSelected: Bool = false
-
-    var body: some View {
-        HStack(spacing: 12) {
+        NavigationStack {
             ZStack {
-                Circle()
-                    .fill(isSelected ? Color.green : Color.gray.opacity(0.4))
-                    .frame(width: 36, height: 36)
-                Image(systemName: "person.fill")
-                    .foregroundStyle(.white)
+                background
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        Text("Tap the device you want to pair with. Both sides must tap each other to confirm the pairing.")
+                            .font(.headline)
+                            .foregroundStyle(.white)
+                            .padding()
+                            .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                        ForEach(model.peers) { peer in
+                            PairingCard(
+                                peer: peer,
+                                onTap: { model.toggleLocalTap(for: peer.id) },
+                                onSimulateRemote: { model.simulateRemoteTap(for: peer.id) }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.top, 32)
+                    .padding(.bottom, 40)
+                }
+            }
+            .navigationTitle("Pairing")
+        }
+    }
+
+    private var background: some View {
+        LinearGradient(
+            colors: [Color(hue: 0.67, saturation: 0.65, brightness: 0.22),
+                     Color(hue: 0.73, saturation: 0.60, brightness: 0.20)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .ignoresSafeArea()
+    }
+}
+
+private struct PairingCard: View {
+    let peer: PairingPeer
+    let onTap: () -> Void
+    let onSimulateRemote: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(peer.name)
+                        .font(.title3.weight(.semibold))
+                    Text(peer.subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(.white.opacity(0.75))
+                }
+                Spacer()
+                statusBadge
             }
 
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 8) {
-                    Text(participant.name)
-                        .foregroundStyle(.white)
-                        .font(.system(size: 16, weight: .semibold))
-                    if participant.isSpeaking {
-                        Text("Speaking")
-                            .font(.caption2.weight(.bold))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 3)
-                            .background(Color.green.opacity(0.18))
-                            .foregroundStyle(.green)
-                            .clipShape(Capsule())
-                    }
+            Divider().background(Color.white.opacity(0.1))
+
+            HStack(spacing: 12) {
+                Button(action: onTap) {
+                    Label(peer.localTapped ? "Cancel" : "Tap to Pair", systemImage: peer.localTapped ? "xmark" : "hand.point.up.left")
+                        .font(.subheadline.weight(.semibold))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(peer.localTapped ? Color.red.opacity(0.25) : Color.green.opacity(0.25), in: Capsule())
                 }
-                .lineLimit(1)
-                Text(participant.feed.connectionState)
-                    .font(.caption2)
+                .buttonStyle(.plain)
+                .foregroundStyle(peer.localTapped ? Color.red : Color.green)
+
+                if !peer.remoteTapped {
+                    Button(action: onSimulateRemote) {
+                        Label("Simulate remote tap", systemImage: "sparkles")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.white.opacity(0.7))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(.white.opacity(0.08), in: Capsule())
+                }
+            }
+
+            Text(peer.guidance)
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.7))
+        }
+        .padding(20)
+        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(peer.isReady ? Color.green.opacity(0.6) : Color.white.opacity(0.05), lineWidth: 1.5)
+        )
+    }
+
+    private var statusBadge: some View {
+        Group {
+            if peer.isReady {
+                Label("Ready", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            } else if peer.localTapped {
+                Label("Waiting", systemImage: "hourglass")
+                    .foregroundStyle(.yellow)
+            } else if peer.remoteTapped {
+                Label("Incoming", systemImage: "bolt.horizontal.fill")
+                    .foregroundStyle(.cyan)
+            } else {
+                Label("Available", systemImage: "antenna.radiowaves.left.and.right")
                     .foregroundStyle(.white.opacity(0.7))
             }
-            Spacer()
-
-            if participant.isMuted {
-                Image(systemName: "speaker.slash.fill")
-                    .foregroundStyle(.red)
-            }
         }
-        .padding(14)
-        .background(
-            ZStack {
-                if isSelected {
-                    LinearGradient(colors: [Color.white.opacity(0.06), Color.white.opacity(0.02)], startPoint: .top, endPoint: .bottom)
-                } else {
-                    Color.white.opacity(0.05)
-                }
-            }
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 14)
-                .stroke(isSelected ? Color.green.opacity(0.6) : .clear, lineWidth: 2)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .font(.caption.weight(.semibold))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(.black.opacity(0.4), in: Capsule())
     }
 }
 
-struct FooterCircleButton: View {
-    let systemName: String
-    let action: () -> Void
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: systemName)
-                .font(.title3)
-                .foregroundStyle(.white)
-                .frame(width: 44, height: 44)
-                .background(.ultraThinMaterial.opacity(0.2))
-                .clipShape(Circle())
-        }
-        .buttonStyle(.plain)
-    }
-}
+// MARK: - Role Selection
 
-// MARK: - Stage Grid
-struct StageGrid: View {
-    let participants: [StageParticipant]
-    @Binding var selectedId: UUID?
-    var isCompact: Bool = false
-    var onSelect: (UUID) -> Void
-
-    private var columns: [GridItem] {
-        if isCompact {
-            return [GridItem(.adaptive(minimum: 220, maximum: 380), spacing: 12)]
-        } else {
-            return Array(repeating: GridItem(.flexible(), spacing: 16), count: 2)
-        }
-    }
-
-    var body: some View {
-        LazyVGrid(columns: columns, spacing: isCompact ? 12 : 16) {
-            ForEach(participants) { p in
-                VideoTile(participant: p, isSelected: p.id == selectedId, isCompact: isCompact)
-                    .onTapGesture { onSelect(p.id) }
-            }
-        }
-    }
-}
-
-struct VideoTile: View {
-    let participant: StageParticipant
-    var isSelected: Bool = false
-    var isCompact: Bool = false
+private struct RoleSelectionScreen: View {
+    let peer: PairingPeer
+    let onSelect: (PairingRole) -> Void
+    let onBack: () -> Void
+    @State private var selectedRole: PairingRole = .camera
 
     var body: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color.black.opacity(0.75))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16)
-                        .stroke(isSelected ? Color.green : .clear, lineWidth: 3)
-                )
+            LinearGradient(
+                colors: [Color(hue: 0.66, saturation: 0.65, brightness: 0.22),
+                         Color(hue: 0.58, saturation: 0.40, brightness: 0.25)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
 
-            if participant.feed.isPublishing, participant.feed.isVideoEnabled, let image = participant.feed.currentFrame {
+            VStack(spacing: 28) {
+                VStack(spacing: 10) {
+                    Text("Pair with \(peer.name)")
+                        .font(.largeTitle.bold())
+                    Text("Decide whether this device will act as the camera or the viewer for this session.")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.75))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                }
+
+                Picker("Role", selection: $selectedRole) {
+                    Text("Camera").tag(PairingRole.camera)
+                    Text("Viewer").tag(PairingRole.viewer)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 40)
+
+                RoleDescription(role: selectedRole)
+                    .padding(.horizontal, 24)
+
+                Button {
+                    onSelect(selectedRole)
+                } label: {
+                    Label(selectedRole == .camera ? "Start as Camera" : "Join as Viewer",
+                          systemImage: selectedRole == .camera ? "video.fill" : "eye")
+                        .font(.title3.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Color.green, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 32)
+
+                Button(action: onBack) {
+                    Label("Back", systemImage: "chevron.left")
+                        .font(.subheadline.weight(.semibold))
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 8)
+                        .background(.white.opacity(0.08), in: Capsule())
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+            }
+            .padding(.top, 80)
+        }
+    }
+}
+
+private struct RoleDescription: View {
+    let role: PairingRole
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(role == .camera ? "Camera responsibilities" : "Viewer responsibilities",
+                  systemImage: role == .camera ? "camera" : "eye")
+                .font(.headline)
+
+            Text(role == .camera ? cameraText : viewerText)
+                .foregroundStyle(.white.opacity(0.75))
+                .font(.body)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    private var cameraText: String {
+        "The camera role will publish live video and audio from this device. As soon as you continue, capture starts automatically so the paired viewer can watch in real-time."
+    }
+
+    private var viewerText: String {
+        "The viewer role receives the live camera feed from your paired partner. We will automatically connect to the stream and display it on the stage once the camera comes online."
+    }
+}
+
+// MARK: - Stage
+
+private struct StageScreen: View {
+    let session: StageSession
+    let onEnd: (StageSession) -> Void
+
+    var body: some View {
+        StageBody(session: session, media: session.mediaCoordinator) {
+            onEnd(session)
+        }
+    }
+}
+
+private struct StageBody: View {
+    let session: StageSession
+    @ObservedObject var media: StageMediaCoordinator
+    let onEnd: () -> Void
+    @State private var showEndAlert = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color(hue: 0.65, saturation: 0.62, brightness: 0.22),
+                         Color(hue: 0.72, saturation: 0.58, brightness: 0.20)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 28) {
+                header
+
+                Group {
+                    if session.localRole == .camera {
+                        CameraPublisherView(sender: media.makeCameraSender(), autoStartPublishing: true)
+                            .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+                    } else {
+                        ViewerFeedView(media: media, remoteName: session.peer.name)
+                            .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 360)
+                .shadow(radius: 30, y: 10)
+
+                ParticipantsStrip(session: session, media: media)
+
+                Button(role: .destructive) {
+                    showEndAlert = true
+                } label: {
+                    Label("End session", systemImage: "phone.down.fill")
+                        .font(.headline)
+                        .padding(.horizontal, 26)
+                        .padding(.vertical, 12)
+                        .background(Color.red.opacity(0.2), in: Capsule())
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.plain)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 28)
+            .padding(.top, 36)
+            .padding(.bottom, 24)
+        }
+        .alert("End Session?", isPresented: $showEndAlert) {
+            Button("End", role: .destructive) {
+                media.stop()
+                onEnd()
+            }
+            Button("Continue", role: .cancel) {}
+        } message: {
+            Text("This will disconnect from \(session.peer.name) and return to the pairing lobby.")
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 6) {
+            Text(session.localRole == .camera ? "Camera Session" : "Viewer Session")
+                .font(.title2.weight(.semibold))
+            Text(statusLine)
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.75))
+        }
+    }
+
+    private var statusLine: String {
+        if session.localRole == .camera {
+            return "Publishing to \(session.peer.name)"
+        } else {
+            return "Watching live from \(session.peer.name)"
+        }
+    }
+}
+
+private struct ViewerFeedView: View {
+    @ObservedObject var media: StageMediaCoordinator
+    let remoteName: String
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .fill(Color.black.opacity(0.75))
+
+            if let image = media.latestFrame {
                 Image(uiImage: image)
                     .resizable()
                     .scaledToFill()
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-            } else {
-                VStack {
-                    Spacer()
-                    Circle()
-                        .fill(participant.isSpeaking ? Color.green : Color.gray.opacity(0.6))
-                        .frame(width: isCompact ? 72 : 96, height: isCompact ? 72 : 96)
-                        .overlay(
-                            Image(systemName: "person.fill")
-                                .font(.system(size: 44, weight: .bold))
-                                .foregroundStyle(.white)
-                        )
-                    Spacer()
-                }
-            }
-
-            // Name tag top-left
-            VStack {
-                HStack(spacing: 8) {
-                    Text(participant.name)
-                        .font(.subheadline.weight(.semibold))
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(.black.opacity(0.6))
-                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                    Text(participant.feed.connectionState)
-                        .font(.caption.weight(.semibold))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(.black.opacity(0.45))
-                        .clipShape(Capsule())
-                    Circle()
-                        .fill(participant.isSpeaking ? Color.green : Color.gray)
-                        .frame(width: 8, height: 8)
-                    Spacer()
-                }
-                .foregroundStyle(.white)
-                .padding(10)
-                Spacer()
-            }
-
-            // Mute badge bottom-right
-            VStack {
-                Spacer()
-                HStack {
-                    Spacer()
-                    if participant.isMuted {
-                        Circle()
-                            .fill(Color.red)
-                            .frame(width: isCompact ? 26 : 30, height: isCompact ? 26 : 30)
-                            .overlay(Image(systemName: "speaker.slash.fill").foregroundStyle(.white))
-                            .padding(isCompact ? 10 : 12)
-                    } else if participant.isVideoOff {
-                        Circle()
-                            .fill(Color.orange)
-                            .frame(width: isCompact ? 26 : 30, height: isCompact ? 26 : 30)
-                            .overlay(Image(systemName: "video.slash.fill").foregroundStyle(.white))
-                            .padding(isCompact ? 10 : 12)
+                    .clipped()
+                    .overlay(alignment: .topLeading) {
+                        statusPill("Watching \(remoteName)")
+                            .padding(12)
                     }
+                    .overlay(alignment: .bottomTrailing) {
+                        statusPill(media.cameraStatus)
+                            .padding(12)
+                    }
+            } else {
+                VStack(spacing: 14) {
+                    ProgressView()
+                        .tint(.green)
+                    Text(media.cameraStatus)
+                        .font(.callout)
+                        .foregroundStyle(.white.opacity(0.8))
                 }
             }
         }
-        .aspectRatio(16/9, contentMode: .fit)
+    }
+
+    private func statusPill(_ text: String) -> some View {
+        Text(text)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Color.black.opacity(0.45), in: Capsule())
     }
 }
 
-// MARK: - Bottom Controls
-struct BottomControlBar: View {
-    var onToggleMute: () -> Void
-    var onToggleVideo: () -> Void
-    var onShareScreen: () -> Void
-    var onMore: () -> Void
-    var onMention: () -> Void
+private struct ParticipantsStrip: View {
+    let session: StageSession
+    @ObservedObject var media: StageMediaCoordinator
 
     var body: some View {
-        HStack(spacing: 18) {
-            ControlCircleButton(symbol: "speaker.slash.fill", isDestructive: true, action: onToggleMute)
-            ControlCircleButton(symbol: "video.slash.fill", isDestructive: true, action: onToggleVideo)
-            ControlCircleButton(symbol: "display", isDestructive: false, action: onShareScreen)
-            ControlCircleButton(symbol: "ellipsis", isDestructive: false, action: onMore)
-            ControlCircleButton(symbol: "at.circle.fill", isDestructive: true, action: onMention)
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Participants")
+                .font(.headline)
+
+            HStack(spacing: 14) {
+                ParticipantBadge(name: "You", role: session.localRole, status: localStatus, highlight: true)
+                ParticipantBadge(name: session.peer.name, role: session.remoteRole, status: remoteStatus, highlight: false)
+                Spacer()
+            }
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 12)
-        .background(.ultraThinMaterial.opacity(0.2))
-        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    private var localStatus: String {
+        switch session.localRole {
+        case .camera:
+            return media.cameraStatus
+        case .viewer:
+            return "Connected"
+        }
+    }
+
+    private var remoteStatus: String {
+        switch session.remoteRole {
+        case .camera:
+            return media.cameraStatus
+        case .viewer:
+            return session.localRole == .camera ? "Receiving" : "Ready"
+        }
     }
 }
 
-struct ControlCircleButton: View {
-    let symbol: String
-    var isDestructive: Bool = false
-    var action: () -> Void
+private struct ParticipantBadge: View {
+    let name: String
+    let role: PairingRole
+    let status: String
+    var highlight: Bool
 
     var body: some View {
-        Button(action: action) {
-            Image(systemName: symbol)
-                .font(.title2.weight(.semibold))
-                .foregroundStyle(.white)
-                .frame(width: 56, height: 56)
-                .background(
-                    Circle().fill(isDestructive ? Color.red : Color.gray.opacity(0.5))
-                )
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: role == .camera ? "video.fill" : "eye")
+                Text(role.rawValue)
+            }
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(highlight ? Color.green : Color.white.opacity(0.8))
+
+            Text(name)
+                .font(.headline)
+
+            Text(status)
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.7))
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(Text(symbol))
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(highlight ? Color.green.opacity(0.18) : Color.white.opacity(0.05),
+                    in: RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }
 
-// MARK: - MockMediaSender for Preview/Testing
-import AVFoundation
-import Combine
+// MARK: - Coordinator
 
-final class MockMediaSender: MediaSender {
-    private let state = CurrentValueSubject<String, Never>("Idle")
-    var connectionStatePublisher: AnyPublisher<String, Never> { state.eraseToAnyPublisher() }
+@MainActor
+final class AppCoordinator: ObservableObject {
+    enum Route: Equatable {
+        case pairing
+        case roleSelection(PairingPeer)
+        case stage(StageSession)
+    }
 
-    func startPublishing() async throws { state.send("Connected") }
-    func stopPublishing() { state.send("Stopped") }
+    @Published var route: Route = .pairing
+    @Published var pairingModel: PairingModel
 
-    func sendVideo(sampleBuffer: CMSampleBuffer) { /* no-op for mock */ }
-    func sendAudio(sampleBuffer: CMSampleBuffer) { /* no-op for mock */ }
+    private var cancellables = Set<AnyCancellable>()
 
-    func setReturnAudioEnabled(_ enabled: Bool) { /* no-op */ }
-    func pushToTalk(_ isDown: Bool) { /* no-op */ }
+    init(pairingModel: PairingModel = PairingModel()) {
+        self.pairingModel = pairingModel
+
+        pairingModel.$activePairing
+            .compactMap { $0 }
+            .removeDuplicates()
+            .sink { [weak self] peer in
+                self?.route = .roleSelection(peer)
+            }
+            .store(in: &cancellables)
+    }
+
+    func confirmRole(_ role: PairingRole, for peer: PairingPeer) {
+        pairingModel.setRole(role, for: peer.id)
+        let updatedPeer = pairingModel.peer(for: peer.id) ?? peer
+        let session = StageSession(peer: updatedPeer, localRole: role)
+        pairingModel.clearActivePairing()
+        route = .stage(session)
+    }
+
+    func cancelRoleSelection() {
+        pairingModel.clearActivePairing()
+        route = .pairing
+    }
+
+    func endSession(_ session: StageSession) {
+        pairingModel.endSession(for: session.peer.id)
+        route = .pairing
+    }
+
+    fileprivate var routeID: String {
+        switch route {
+        case .pairing: return "pairing"
+        case .roleSelection(let peer): return "role-\(peer.id)"
+        case .stage(let session): return "stage-\(session.id)"
+        }
+    }
 }
 
 // MARK: - Preview
+
 #Preview {
     ContentView()
-        .previewInterfaceOrientation(.landscapeLeft)
+        .preferredColorScheme(.dark)
 }

--- a/Tele Teams/PairingModel.swift
+++ b/Tele Teams/PairingModel.swift
@@ -1,0 +1,129 @@
+//
+//  PairingModel.swift
+//  Tele Teams
+//
+//  New pairing flow model that keeps the handshake state simple and explicit.
+//
+
+import Foundation
+
+enum PairingRole: String, CaseIterable, Identifiable {
+    case camera = "Camera"
+    case viewer = "Viewer"
+
+    var id: String { rawValue }
+
+    var opposite: PairingRole {
+        switch self {
+        case .camera: return .viewer
+        case .viewer: return .camera
+        }
+    }
+}
+
+struct PairingPeer: Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var detail: String
+    var localTapped: Bool = false
+    var remoteTapped: Bool = false
+    var localRole: PairingRole?
+    var remoteRole: PairingRole?
+
+    var isReady: Bool { localTapped && remoteTapped }
+
+    var subtitle: String { detail }
+
+    var guidance: String {
+        if isReady {
+            return "Both sides have tapped. Continue to choose who will be the camera and who will watch."
+        }
+        if localTapped {
+            return "Waiting for \(name) to tap you back."
+        }
+        if remoteTapped {
+            return "\(name) tapped you. Tap them back to accept the pairing."
+        }
+        return "Tap to send \(name) a pairing request."
+    }
+}
+
+@MainActor
+final class PairingModel: ObservableObject {
+    @Published private(set) var peers: [PairingPeer]
+    @Published var activePairing: PairingPeer?
+
+    init(peers: [PairingPeer] = PairingPeer.samples) {
+        self.peers = peers
+    }
+
+    func toggleLocalTap(for id: UUID) {
+        guard let idx = peers.firstIndex(where: { $0.id == id }) else { return }
+        peers[idx].localTapped.toggle()
+        if !peers[idx].localTapped {
+            // Reset handshake when cancelled.
+            peers[idx].remoteTapped = false
+            peers[idx].localRole = nil
+            peers[idx].remoteRole = nil
+            if activePairing?.id == id {
+                activePairing = nil
+            }
+        }
+        evaluatePairing(at: idx)
+    }
+
+    func registerRemoteTap(for id: UUID) {
+        guard let idx = peers.firstIndex(where: { $0.id == id }) else { return }
+        peers[idx].remoteTapped = true
+        evaluatePairing(at: idx)
+    }
+
+    func simulateRemoteTap(for id: UUID) {
+        // Prototype helper so designers can see the flow without a second device.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+            self?.registerRemoteTap(for: id)
+        }
+    }
+
+    func setRole(_ role: PairingRole, for id: UUID) {
+        guard let idx = peers.firstIndex(where: { $0.id == id }) else { return }
+        peers[idx].localRole = role
+        peers[idx].remoteRole = role.opposite
+    }
+
+    func clearActivePairing() {
+        activePairing = nil
+    }
+
+    func endSession(for id: UUID) {
+        guard let idx = peers.firstIndex(where: { $0.id == id }) else { return }
+        peers[idx].localTapped = false
+        peers[idx].remoteTapped = false
+        peers[idx].localRole = nil
+        peers[idx].remoteRole = nil
+        if activePairing?.id == id {
+            activePairing = nil
+        }
+    }
+
+    func peer(for id: UUID) -> PairingPeer? {
+        peers.first(where: { $0.id == id })
+    }
+
+    private func evaluatePairing(at index: Int) {
+        let peer = peers[index]
+        if peer.localTapped && peer.remoteTapped {
+            activePairing = peer
+        } else if activePairing?.id == peer.id {
+            activePairing = nil
+        }
+    }
+}
+
+private extension PairingPeer {
+    static let samples: [PairingPeer] = [
+        PairingPeer(id: UUID(), name: "Director iPad", detail: "Control Room • Wi‑Fi 6"),
+        PairingPeer(id: UUID(), name: "Stage Cam 1", detail: "Studio Floor • 5G", remoteTapped: true),
+        PairingPeer(id: UUID(), name: "Back Row Viewer", detail: "Audience • Ethernet")
+    ]
+}

--- a/Tele Teams/StageSession.swift
+++ b/Tele Teams/StageSession.swift
@@ -1,0 +1,182 @@
+//
+//  StageSession.swift
+//  Tele Teams
+//
+//  Defines the lightweight session container and media bridge between
+//  the publishing camera and the viewer stage.
+//
+
+import Foundation
+import UIKit
+import Combine
+import AVFoundation
+import VideoToolbox
+
+struct StageSession: Identifiable, Equatable {
+    let id = UUID()
+    let peer: PairingPeer
+    let localRole: PairingRole
+    let remoteRole: PairingRole
+    let mediaCoordinator: StageMediaCoordinator
+
+    init(peer: PairingPeer, localRole: PairingRole, mediaCoordinator: StageMediaCoordinator = StageMediaCoordinator()) {
+        self.peer = peer
+        self.localRole = localRole
+        self.remoteRole = localRole.opposite
+        self.mediaCoordinator = mediaCoordinator
+
+        switch localRole {
+        case .camera:
+            mediaCoordinator.cameraStatus = "Waiting to start"
+        case .viewer:
+            mediaCoordinator.startSimulatedRemoteCamera(named: peer.name)
+        }
+    }
+
+    static func == (lhs: StageSession, rhs: StageSession) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+@MainActor
+final class StageMediaCoordinator: ObservableObject {
+    @Published var latestFrame: UIImage?
+    @Published var cameraStatus: String = "Idle"
+
+    private var remoteTimer: Timer?
+
+    func makeCameraSender() -> MediaSender {
+        cameraStatus = "Connecting"
+        return StageCameraSender(coordinator: self)
+    }
+
+    func startSimulatedRemoteCamera(named name: String) {
+        stop()
+        cameraStatus = "Connecting to \(name)…"
+
+        var step = 0
+        remoteTimer = Timer.scheduledTimer(withTimeInterval: 0.7, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            step += 1
+            if step < 3 {
+                self.cameraStatus = "Connecting…"
+            } else {
+                self.cameraStatus = "Live from \(name)"
+            }
+            self.latestFrame = StageMediaCoordinator.makeDemoFrame(index: step, label: name)
+        }
+    }
+
+    func stop() {
+        remoteTimer?.invalidate()
+        remoteTimer = nil
+        latestFrame = nil
+        cameraStatus = "Idle"
+    }
+
+    private static func makeDemoFrame(index: Int, label: String) -> UIImage {
+        let size = CGSize(width: 1280, height: 720)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let hue = CGFloat((Double((index % 20)) / 20.0).truncatingRemainder(dividingBy: 1.0))
+        let topColor = UIColor(hue: hue, saturation: 0.55, brightness: 0.9, alpha: 1)
+        let bottomColor = UIColor(hue: (hue + 0.1).truncatingRemainder(dividingBy: 1.0), saturation: 0.65, brightness: 0.65, alpha: 1)
+        let timeString = DateFormatter.cached.string(from: Date())
+
+        return renderer.image { ctx in
+            if let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(),
+                                         colors: [topColor.cgColor, bottomColor.cgColor] as CFArray,
+                                         locations: [0, 1]) {
+                ctx.cgContext.drawLinearGradient(gradient,
+                                                 start: CGPoint(x: 0, y: 0),
+                                                 end: CGPoint(x: 0, y: size.height),
+                                                 options: [])
+            }
+
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.alignment = .center
+
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: 64, weight: .bold),
+                .foregroundColor: UIColor.white,
+                .paragraphStyle: paragraph
+            ]
+            let subAttributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: 28, weight: .semibold),
+                .foregroundColor: UIColor.white.withAlphaComponent(0.9),
+                .paragraphStyle: paragraph
+            ]
+
+            let title = "Live feed"
+            let titleRect = CGRect(x: 0, y: size.height * 0.35 - 40, width: size.width, height: 80)
+            title.draw(in: titleRect, withAttributes: attributes)
+
+            let subtitle = "\(label) • \(timeString)"
+            let subtitleRect = CGRect(x: 0, y: size.height * 0.35 + 50, width: size.width, height: 40)
+            subtitle.draw(in: subtitleRect, withAttributes: subAttributes)
+        }
+    }
+}
+
+private final class StageCameraSender: MediaSender {
+    private weak var coordinator: StageMediaCoordinator?
+    private let state = CurrentValueSubject<String, Never>("Idle")
+
+    init(coordinator: StageMediaCoordinator) {
+        self.coordinator = coordinator
+        state.send("Connecting")
+    }
+
+    var connectionStatePublisher: AnyPublisher<String, Never> {
+        state.eraseToAnyPublisher()
+    }
+
+    func startPublishing() async throws {
+        await MainActor.run {
+            coordinator?.cameraStatus = "Streaming"
+        }
+        state.send("Streaming")
+    }
+
+    func stopPublishing() {
+        Task { @MainActor in
+            coordinator?.cameraStatus = "Stopped"
+            coordinator?.latestFrame = nil
+        }
+        state.send("Stopped")
+    }
+
+    func sendVideo(sampleBuffer: CMSampleBuffer) {
+        guard let coordinator else { return }
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        var cgImage: CGImage?
+        VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
+        guard let cgImage else { return }
+
+        let image = UIImage(cgImage: cgImage)
+        DispatchQueue.main.async {
+            coordinator.latestFrame = image
+        }
+    }
+
+    func sendAudio(sampleBuffer: CMSampleBuffer) {
+        // The prototype keeps audio local.
+    }
+
+    func setReturnAudioEnabled(_ enabled: Bool) {
+        // Not required for the in-memory bridge.
+    }
+
+    func pushToTalk(_ isDown: Bool) {
+        // No-op for the prototype bridge.
+    }
+}
+
+private extension DateFormatter {
+    static let cached: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .medium
+        formatter.dateStyle = .none
+        return formatter
+    }()
+}


### PR DESCRIPTION
## Summary
- redesign the root experience to drive a pairing → role selection → stage flow
- add a focused pairing model and stage media coordinator for clear camera/viewer assignments
- allow the camera publisher surface to auto-start streaming when launched in camera mode

## Testing
- Not run (Xcode is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d02e4fdf28832799efac691faf7104